### PR TITLE
Fix | Bootstrap process admin

### DIFF
--- a/src/server/error/user.service.ts
+++ b/src/server/error/user.service.ts
@@ -21,3 +21,11 @@ export class InvalidUserRole extends Error {
     this.name = 'InvalidUserRole';
   }
 }
+
+export class AdminUserAlreadyExists extends Error {
+  constructor() {
+    super('Attempted to create an "admin" user, but such user already exists');
+
+    this.name = 'AdminUserAlreadyExists';
+  }
+}

--- a/src/server/routes/api/v1/users/index.ts
+++ b/src/server/routes/api/v1/users/index.ts
@@ -1,5 +1,8 @@
 import httpResponse from '../../../../utils/http-response';
-import { InvalidUserRole } from '../../../../error/user.service';
+import {
+  AdminUserAlreadyExists,
+  InvalidUserRole,
+} from '../../../../error/user.service';
 import { Role } from '../../../../models/user';
 import validationSchema from './validation-schema';
 
@@ -36,6 +39,10 @@ export default function (
       } catch (error) {
         if (error instanceof InvalidUserRole) {
           return httpResponse.badRequestMessage(reply, error.message);
+        }
+
+        if (error instanceof AdminUserAlreadyExists) {
+          return httpResponse.forbiddenMessage(reply, error.message);
         }
 
         return httpResponse.internalServerError(reply, error);

--- a/src/server/utils/bootstrap.ts
+++ b/src/server/utils/bootstrap.ts
@@ -37,7 +37,7 @@ export default async function bootstrap(services: Services): Promise<void> {
   try {
     await createAdmin(services);
   } catch (error) {
-    services.logger.error('An error ocurred during "bootsrap" process');
+    services.logger.error('An error ocurred during the "bootstrap" process');
     services.logger.error(error);
   }
 }

--- a/src/server/utils/bootstrap.ts
+++ b/src/server/utils/bootstrap.ts
@@ -27,7 +27,7 @@ async function createAdmin(services: Services): Promise<void> {
       return;
     }
 
-    services.logger.info('No "admin" user were created');
+    services.logger.info('No "admin" user was created');
 
     return;
   } catch (error) {


### PR DESCRIPTION
- Update admin user creation to support `UserByEmailNotFound` error
- Validate `User` creation to avoid having more than one `admin` user coexisting
- Fix typo on error message logged to stdout
