### PR TITLE
Feature | impl "useAxios" and "useRequest" hooks

### DIFF
--- a/src/client/hooks/use-axios.ts
+++ b/src/client/hooks/use-axios.ts
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import axios from 'axios';
+
+import type { AxiosResponse, AxiosRequestConfig } from 'axios';
+
+export interface UseAxiosHook<T> {
+  error: Error | null;
+  execute(params: AxiosRequestConfig): Promise<AxiosResponse<T>>;
+  response: T | null;
+  isLoading: boolean;
+}
+
+export default function useAxios<T>(): UseAxiosHook<T> {
+  const [response, setResponse] = useState<T | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [isLoading, setLoading] = useState<boolean>(false);
+
+  const execute = async (
+    params: AxiosRequestConfig,
+  ): Promise<AxiosResponse<T>> => {
+    setLoading(true);
+
+    try {
+      const result = await axios.request(params);
+
+      setResponse(result.data);
+
+      return result;
+    } catch (error) {
+      setError(error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    error,
+    execute,
+    response,
+    isLoading,
+  };
+}

--- a/src/client/hooks/use-request.ts
+++ b/src/client/hooks/use-request.ts
@@ -1,0 +1,45 @@
+import { useCallback, useState } from 'react';
+import axios from 'axios';
+
+import type { AxiosResponse, AxiosRequestConfig } from 'axios';
+
+export interface UseRequestHook<T> {
+  error: Error | null;
+  execute(params: AxiosRequestConfig): Promise<AxiosResponse<T>>;
+  response: T | null;
+  isLoading: boolean;
+}
+
+export default function useRequest<T>(
+  params: AxiosRequestConfig,
+): UseRequestHook<T> {
+  const [response, setResponse] = useState<T | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [isLoading, setLoading] = useState<boolean>(false);
+
+  const execute = useCallback(async (data?: unknown) => {
+    setLoading(true);
+
+    try {
+      const result = await axios.request({
+        ...params,
+        data: data ?? null,
+      });
+
+      setResponse(result.data);
+
+      return result;
+    } catch (error) {
+      setError(error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return {
+    error,
+    execute,
+    response,
+    isLoading,
+  };
+}


### PR DESCRIPTION
I would like to have hooks for HTTP requests. The main goal is to encapsulate the HTTP configuration, such as HTTP headers,
how we access HTTP bodies, responses, and handle errors.

This is most of an experiment as there's no major progress in the FE so we can have some testing in the middle before sticking to this.